### PR TITLE
Update key find within sort-files

### DIFF
--- a/Cookbook/Series/SeriesTransmissionshowRSS.md
+++ b/Cookbook/Series/SeriesTransmissionshowRSS.md
@@ -20,7 +20,7 @@ tasks:
       password: password
   # sorting task
   sort-files:
-    find:
+    filesystem:
       # directory with the files to be sorted
       path: /home/solenoid/Downloads/
       # fetch all avi, mkv and mp4 files, skips the .part files (unfinished torrents)


### PR DESCRIPTION
To avoid this error: 

```
[/tasks/sort-files] The key `find` is not valid here. Only known plugin names are valid keys.
```

I had to remove find and put filesystem instead.

```
python2 --version                                                        
Python 2.7.11
pip2 freeze | grep FlexGet                                              
FlexGet==2.0.25
```

Cheers.
