### PR TITLE
docs: Update InstallWizard/Docker.md

### DIFF
--- a/InstallWizard/Docker.md
+++ b/InstallWizard/Docker.md
@@ -23,7 +23,7 @@ Follow the instructions for your operating system [here](https://docs.docker.com
 ### LinuxServer.io
 
 - lscr.io/linuxserver/flexget
-- [linuxserver/flexget](https://hub.docker/com/r/linuxserver/flexget)
+- [linuxserver/flexget](https://hub.docker.com/r/linuxserver/flexget)
 - [ghcr.io/linuxserver/flexget](https://github.com/linuxserver/docker-flexget/pkgs/container/flexget)
 
 #### Based on python:3.11-alpine


### PR DESCRIPTION
fix an invalid URL

`hub.docker/com` -> `hub.docker.com`